### PR TITLE
リアクションがトグルされない問題を修正しました。

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/NoteRepository.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/NoteRepository.kt
@@ -14,7 +14,13 @@ interface NoteRepository {
 
     suspend fun find(noteId: Note.Id): Note
 
-    suspend fun reaction(createReaction: CreateReaction): Boolean
+    /**
+     * @param createReaction リアクションを作成するための値を表す。
+     * リアクションに成功するとtrueが返される。
+     * 既に選択されているリアクションが選択されている時はtoggleされる。
+     * 既に選択されているリアクションとは異なるリアクションを選択した時は解除してリアクションが作成される。
+     */
+    suspend fun toggleReaction(createReaction: CreateReaction): Boolean
 
     suspend fun unreaction(noteId: Note.Id): Boolean
 }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/impl/NoteRepositoryImpl.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/impl/NoteRepositoryImpl.kt
@@ -76,12 +76,17 @@ class NoteRepositoryImpl(
     }
 
     @ExperimentalCoroutinesApi
-    override suspend fun reaction(createReaction: CreateReaction): Boolean {
+    override suspend fun toggleReaction(createReaction: CreateReaction): Boolean {
         val account = miCore.getAccount(createReaction.noteId.accountId)
         var note = find(createReaction.noteId)
-        if(note.myReaction != null) {
+        if(note.myReaction?.isNotBlank() == true) {
             if(!unreaction(createReaction.noteId)) {
                 return false
+            }
+
+            if(note.myReaction == createReaction.reaction) {
+                logger.debug("同一のリアクションが選択されています。")
+                return true
             }
             note = miCore.getNoteDataSource().get(createReaction.noteId)
         }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/viewmodel/notes/NotesViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/viewmodel/notes/NotesViewModel.kt
@@ -187,7 +187,7 @@ class NotesViewModel(
             }
             Log.d("NotesViewModel", "postReaction(n, n)")
             runCatching {
-                val result = miCore.getNoteRepository().reaction(
+                val result = miCore.getNoteRepository().toggleReaction(
                     CreateReaction(
                         noteId = planeNoteViewData.toShowNote.note.id,
                         reaction = reaction
@@ -207,7 +207,9 @@ class NotesViewModel(
      * 既にリアクションが含まれている場合のみ実行される
      */
     private suspend fun syncDeleteReaction(planeNoteViewData: PlaneNoteViewData){
-        planeNoteViewData.myReaction.value?: return
+        if(planeNoteViewData.myReaction.value.isNullOrBlank()) {
+            return
+        }
         miCore.getNoteRepository().unreaction(planeNoteViewData.toShowNote.note.id)
     }
 


### PR DESCRIPTION
リアクション済みのリアクションをタップした時、
リアクションが一度解除され、再度リアクションが送信されていた問題を修正しました。