### PR TITLE
自分の投稿にRenote解除が表示されないようにしました。

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/view/notes/RenoteBottomSheetDialog.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/view/notes/RenoteBottomSheetDialog.kt
@@ -31,6 +31,7 @@ class RenoteBottomSheetDialog : BottomSheetDialogFragment(){
             val target = notesViewModel.reNoteTarget.event
             if(target?.isRenotedByMe == true){
                 binding.unRenoteBase.visibility = View.VISIBLE
+
             }else{
                 binding.unRenoteBase.visibility = View.GONE
             }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/viewmodel/notes/PlaneNoteViewData.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/viewmodel/notes/PlaneNoteViewData.kt
@@ -49,7 +49,7 @@ open class PlaneNoteViewData (
 
     val isMyNote = account.remoteId == toShowNote.user.id.id
 
-    val isRenotedByMe = note.note.hasContent() && note.user.id.id == account.remoteId
+    val isRenotedByMe = !note.note.hasContent() && note.user.id.id == account.remoteId
 
     val statusMessage: String?
         get(){

--- a/app/src/main/res/layout/dialog_renote.xml
+++ b/app/src/main/res/layout/dialog_renote.xml
@@ -42,6 +42,7 @@
                     />
         </LinearLayout>
         <LinearLayout
+                android:id="@+id/renoteBase"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
@@ -72,6 +73,7 @@
         </LinearLayout>
 
         <LinearLayout
+                android:id="@+id/quoteRenoteBase"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"


### PR DESCRIPTION
自分の投稿に対してRenoteボタンを押すとRenote解除の選択が出てしまい
それをクリックすると投稿が削除されてしまう問題があったのを修正しました。