### PR TITLE
ユーザープロフィールのURLを取得しようとするとホスト部がNullになる問題を修正

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/UserDetailActivity.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/UserDetailActivity.kt
@@ -34,8 +34,7 @@ import jp.panta.misskeyandroidclient.model.account.page.Pageable
 import jp.panta.misskeyandroidclient.model.users.User
 import jp.panta.misskeyandroidclient.view.gallery.GalleryPostsFragment
 import jp.panta.misskeyandroidclient.view.users.ReportDialog
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -313,13 +312,13 @@ class UserDetailActivity : AppCompatActivity() {
                 }
             }
             R.id.share -> {
-                val url = mViewModel?.getProfileUrl()
+                val url = mViewModel?.profileUrl?.value
                     ?: return false
+
                 val intent = Intent().apply {
                     action = Intent.ACTION_SEND
                     type = "text/plain"
                     putExtra(Intent.EXTRA_TEXT, url)
-
                 }
                 startActivity(Intent.createChooser(intent, getString(R.string.share)))
             }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/account/Account.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/account/Account.kt
@@ -25,18 +25,7 @@ data class Account (
     val remoteId: String,
     val instanceDomain: String,
     val userName: String,
-    /*val name: String?,
-    val description: String?,
-    val followersCount: Int,
-    val followingCount: Int,
-    val notesCount: Int,
-    val isBot: Boolean,
-    val isCat: Boolean,
-    val avatarUrl: String?,
-    val bannerUrl: String?,*/
     val encryptedToken: String,
-    //@Ignore val emojis: List<Emoji>,
-
     @Ignore val pages: List<Page>,
     @PrimaryKey(autoGenerate = true) var accountId: Long = 0
 
@@ -47,31 +36,12 @@ data class Account (
     constructor(remoteId: String,
                 instanceDomain: String,
                 userName: String,
-                /*name: String?,
-                description: String?,
-                followersCount: Int,
-                followingCount: Int,
-                notesCount: Int,
-                isBot: Boolean,
-                isCat: Boolean,
-                avatarUrl: String?,
-                bannerUrl: String?,*/
                 encryptedToken: String) :
             this(
                 remoteId,
                 instanceDomain,
                 userName,
-                /*name,
-                description,
-                followersCount,
-                followingCount,
-                notesCount,
-                isBot,
-                isCat,
-                avatarUrl,
-                bannerUrl,*/
                 encryptedToken,
-                //emptyList(),
                 emptyList()
             )
 
@@ -84,6 +54,15 @@ data class Account (
         }catch(e: Exception){
             throw UnauthorizedException()
         }
+    }
+
+    fun getHost(): String {
+        if (instanceDomain.startsWith("https://")) {
+            return instanceDomain.substring("https://".length, instanceDomain.length)
+        } else if (instanceDomain.startsWith("http://")) {
+            return instanceDomain.substring("http://".length, instanceDomain.length)
+        }
+        return instanceDomain
     }
 
 }
@@ -116,7 +95,6 @@ fun UserDTO.newAccount(instanceDomain: String, encryptedToken: String): Account{
         pages = emptyList()
     )
 }
-
 fun AccountRelation.newAccount(user: UserDTO?): Account?{
     val ci = getCurrentConnectionInformation()
         ?: return null

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/users/User.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/users/User.kt
@@ -106,8 +106,8 @@ sealed class User : Entity{
         return "@" + this.userName
     }
 
-    fun getProfileUrl(): String {
-        return "https://$host/${getDisplayUserName()}"
+    fun getProfileUrl(account: Account): String {
+        return "https://${account.instanceDomain}/${getDisplayUserName()}"
     }
 }
 

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/users/User.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/users/User.kt
@@ -107,7 +107,7 @@ sealed class User : Entity{
     }
 
     fun getProfileUrl(account: Account): String {
-        return "https://${account.instanceDomain}/${getDisplayUserName()}"
+        return "https://${account.getHost()}/${getDisplayUserName()}"
     }
 }
 

--- a/app/src/main/java/jp/panta/misskeyandroidclient/viewmodel/users/UserDetailViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/viewmodel/users/UserDetailViewModel.kt
@@ -227,7 +227,9 @@ class UserDetailViewModel(
     }
 
     fun getProfileUrl(): String? {
-        return user.value?.getProfileUrl()
+        return mAc?.let {
+            return user.value?.getProfileUrl(it)
+        }
     }
 
 

--- a/app/src/main/java/jp/panta/misskeyandroidclient/viewmodel/users/UserDetailViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/viewmodel/users/UserDetailViewModel.kt
@@ -4,12 +4,6 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import jp.panta.misskeyandroidclient.api.notes.toEntities
-import jp.panta.misskeyandroidclient.api.throwIfHasError
-import jp.panta.misskeyandroidclient.model.Encryption
-import jp.panta.misskeyandroidclient.api.users.RequestUser
-import jp.panta.misskeyandroidclient.api.users.UserDTO
-import jp.panta.misskeyandroidclient.api.users.toUser
 import jp.panta.misskeyandroidclient.model.account.Account
 import jp.panta.misskeyandroidclient.model.notes.NoteTranslationStore
 import jp.panta.misskeyandroidclient.model.users.User

--- a/app/src/main/java/jp/panta/misskeyandroidclient/viewmodel/users/UserDetailViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/viewmodel/users/UserDetailViewModel.kt
@@ -39,6 +39,11 @@ class UserDetailViewModel(
         } ?: emptyList()
     }
 
+    val profileUrl = userState.filterNotNull().map {
+        val ac = miCore.getAccountRepository().get(it.id.accountId)
+        it.getProfileUrl(ac)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
     val pinNotes = MediatorLiveData<List<PlaneNoteViewData>>().apply {
 
         pinNotesState.map { notes ->
@@ -217,12 +222,6 @@ class UserDetailViewModel(
                     userState.value = it
                 }
             }
-        }
-    }
-
-    fun getProfileUrl(): String? {
-        return mAc?.let {
-            return user.value?.getProfileUrl(it)
         }
     }
 

--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/account/AccountTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/account/AccountTest.kt
@@ -1,0 +1,39 @@
+package jp.panta.misskeyandroidclient.model.account
+
+import junit.framework.TestCase
+
+class AccountTest : TestCase() {
+
+
+
+    fun testGetInstanceDomainWhenHttps() {
+        val account = Account(
+            instanceDomain = "https://example.com",
+            userName = "",
+            encryptedToken = "",
+            remoteId = "remoteId"
+        )
+        assertEquals("example.com", account.getHost())
+    }
+
+    fun testGetInstanceDomainWhenHttp() {
+        val account = Account(
+            instanceDomain = "http://example.com",
+            userName = "",
+            encryptedToken = "",
+            remoteId = "remoteId"
+        )
+        assertEquals("example.com", account.getHost())
+    }
+
+    fun testGetInstanceDomainWhenSchemaLess() {
+        val account = Account(
+            instanceDomain = "example.com",
+            userName = "",
+            encryptedToken = "",
+            remoteId = "remoteId"
+        )
+        assertEquals("example.com", account.getHost())
+    }
+
+}

--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/users/UserTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/users/UserTest.kt
@@ -1,0 +1,41 @@
+package jp.panta.misskeyandroidclient.model.users
+
+import jp.panta.misskeyandroidclient.model.account.Account
+import junit.framework.TestCase
+
+class UserTest : TestCase() {
+
+    fun testGetProfileUrl() {
+
+        val user = User.Simple(
+            id = User.Id(0, "id"),
+            avatarUrl = "",
+            emojis = emptyList(),
+            host = null,
+            isBot = false,
+            isCat = false,
+            name = "Panta",
+            userName = "Panta"
+        )
+
+        val profileUrl = user.getProfileUrl(Account(instanceDomain = "example.com", encryptedToken = "", remoteId = "", userName = ""))
+        assertEquals("https://example.com/@Panta", profileUrl)
+    }
+
+    fun testGetProfileUrlWhenRemoteHost() {
+
+        val user = User.Simple(
+            id = User.Id(0, "id"),
+            avatarUrl = "",
+            emojis = emptyList(),
+            host = "misskey.io",
+            isBot = false,
+            isCat = false,
+            name = "Panta",
+            userName = "Panta"
+        )
+
+        val profileUrl = user.getProfileUrl(Account(instanceDomain = "example.com", encryptedToken = "", remoteId = "", userName = ""))
+        assertEquals("https://example.com/@Panta@misskey.io", profileUrl)
+    }
+}

--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/users/UserTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/users/UserTest.kt
@@ -18,7 +18,13 @@ class UserTest : TestCase() {
             userName = "Panta"
         )
 
-        val profileUrl = user.getProfileUrl(Account(instanceDomain = "example.com", encryptedToken = "", remoteId = "", userName = ""))
+        val profileUrl = user.getProfileUrl(
+            Account(
+                instanceDomain = "https://example.com",
+                encryptedToken = "",
+                remoteId = "",
+                userName = ""
+            ))
         assertEquals("https://example.com/@Panta", profileUrl)
     }
 
@@ -35,7 +41,12 @@ class UserTest : TestCase() {
             userName = "Panta"
         )
 
-        val profileUrl = user.getProfileUrl(Account(instanceDomain = "example.com", encryptedToken = "", remoteId = "", userName = ""))
+        val profileUrl = user.getProfileUrl(Account(
+            instanceDomain = "https://example.com",
+            encryptedToken = "",
+            remoteId = "",
+            userName = ""
+        ))
         assertEquals("https://example.com/@Panta@misskey.io", profileUrl)
     }
 }


### PR DESCRIPTION
ユーザープロフィールのURLを取得しようとするとホスト部がNullになる問題を修正しました。

## 概要
同一インスタンスのユーザーのプロフィールのURLを取得しようとしたところ
ユーザーのプロフィールのURLのホスト部が"null"になってしまう問題を修正しました。

## 何をしたか
Userに関係しているAccountを取得して
そのAccountのHost部を用いてURLを生成するようにしました。