### PR TITLE
下書きノートが適応されない不具合を修正しました

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/NoteEditorActivity.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/NoteEditorActivity.kt
@@ -116,6 +116,9 @@ class NoteEditorActivity : AppCompatActivity(), EmojiSelection {
         )
         mBinding = binding
 
+        binding.lifecycleOwner = this
+        binding.viewModel = mViewModel
+
         setSupportActionBar(mBinding.noteEditorToolbar)
 
 
@@ -135,8 +138,6 @@ class NoteEditorActivity : AppCompatActivity(), EmojiSelection {
             true
         )
 
-        //binding.viewModel
-        binding.lifecycleOwner = this
 
         val accountId: Long? =
             if (intent.getLongExtra(EXTRA_ACCOUNT_ID, -1) == -1L) null else intent.getLongExtra(
@@ -151,8 +152,6 @@ class NoteEditorActivity : AppCompatActivity(), EmojiSelection {
             requireNotNull(accountId)
             Note.Id(accountId, it)
         }
-
-
 
 
         val draftNote: DraftNote? = intent.getSerializableExtra(EXTRA_DRAFT_NOTE) as? DraftNote?
@@ -215,7 +214,9 @@ class NoteEditorActivity : AppCompatActivity(), EmojiSelection {
         }
         mViewModel.setReplyTo(replyToNoteId)
         mViewModel.setRenoteTo(quoteToNoteId)
-        mViewModel.setDraftNote(draftNote)
+        if (draftNote != null) {
+            mViewModel.setDraftNote(draftNote)
+        }
         binding.viewModel = mViewModel
         noteEditorToolbar.viewModel = mViewModel
         noteEditorToolbar.lifecycleOwner = this
@@ -266,6 +267,7 @@ class NoteEditorActivity : AppCompatActivity(), EmojiSelection {
         }
 
         mBinding.inputMain.addTextChangedListener { e ->
+            Log.d("NoteEditorActivity", "text changed:$e")
             mViewModel.setText((e?.toString() ?: ""))
         }
 

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/editor/NoteEditorViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/editor/NoteEditorViewModel.kt
@@ -45,10 +45,10 @@ class NoteEditorViewModel @Inject constructor(
 
     val text = _state.map {
         it.text
-    }.stateIn(viewModelScope, started = SharingStarted.Eagerly, initialValue = null)
+    }.stateIn(viewModelScope, started = SharingStarted.Lazily, initialValue = null)
     val cw = _state.map {
         it.cw
-    }.stateIn(viewModelScope, started = SharingStarted.Eagerly, initialValue = null)
+    }.stateIn(viewModelScope, started = SharingStarted.Lazily, initialValue = null)
 
     private val currentAccount = MutableLiveData<Account>().apply {
         miCore.getCurrentAccount().onEach {
@@ -91,7 +91,7 @@ class NoteEditorViewModel @Inject constructor(
         metaRepository.get(it.instanceDomain)?.maxNoteTextLength ?: 1500
     }.stateIn(viewModelScope + Dispatchers.IO, started = SharingStarted.Lazily, initialValue = 1500)
 
-    val textRemaining = combine(maxTextLength, text) { max, t ->
+    val textRemaining = combine(maxTextLength, state.map { it.text }) { max, t ->
         max - (t?.codePointCount(0, t.length) ?: 0)
     }.stateIn(viewModelScope + Dispatchers.IO, started = SharingStarted.Lazily, initialValue = 1500)
 

--- a/app/src/main/res/layout/activity_note_editor.xml
+++ b/app/src/main/res/layout/activity_note_editor.xml
@@ -142,6 +142,7 @@
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toBottomOf="@+id/note_editor_toolbar"
+                            android:text="@{viewModel.text}"
                             />
 
                     <FrameLayout


### PR DESCRIPTION
- ActivityNoteEditorのviewModelにNoteEditorViewModelが割り当てられていない不具合を修正しました。
- stateIn時にSharingStartedをEagerlyにしてしまっていたためViewえの通知のタイミングがずれてしまい正しく値が画面に適応されていなかった問題を修正しました。