### PR TITLE
ノートを表示しようとするとクラッシュする不具合を修正

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/components/AutoCollapsingLayout.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/components/AutoCollapsingLayout.kt
@@ -47,12 +47,14 @@ class AutoCollapsingLayout : FrameLayout {
         @AttrRes defStyleAttr: Int,
         @StyleRes defStyleRes: Int
     ) : super(context, attrs, defStyleAttr, defStyleRes) {
-        context.theme.obtainStyledAttributes(attrs, R.styleable.AutoExpandableLayout, 0, 0).use {
-            it.apply {
-                val buttonId = getResourceId(R.styleable.AutoExpandableLayout_expandableButton, -1)
-                expandableButtonId = if (buttonId == -1) null else buttonId
-            }
+        val a = context.obtainStyledAttributes(
+            attrs, R.styleable.AutoCollapsingLayout, defStyleAttr, defStyleRes)
+        a.apply {
+            val buttonId = getResourceId(R.styleable.AutoCollapsingLayout_expandableButton, -1)
+            expandableButtonId = if (buttonId == -1) null else buttonId
         }
+
+        a.recycle()
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notification/viewmodel/NotificationViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notification/viewmodel/NotificationViewModel.kt
@@ -206,8 +206,10 @@ class NotificationViewModel(
     }
 
     private suspend fun List<NotificationDTO>.toNotificationRelations(account: Account): List<NotificationRelation> {
-        return this.map {
-            it.toNotificationRelation(account)
+        return this.mapNotNull {
+            runCatching {
+                it.toNotificationRelation(account)
+            }.getOrNull()
         }
     }
 

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -8,7 +8,7 @@
         <attr name="metaButtonBarStyle" format="reference" />
         <attr name="metaButtonBarButtonStyle" format="reference" />
     </declare-styleable>
-    <declare-styleable name="AutoExpandableLayout">
+    <declare-styleable name="AutoCollapsingLayout">
         <attr name="expandableButton" format="reference" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
完全に推測になるが
原因としてはKotlinのuseを使用したのが原因の可能性が高い。
Kotlinのuseは最終的にはcloseメソッドを呼び出しているが、
TypedArrayのcloseメソッドは最近実装された上に
さらに機種依存の実装だったため特定の機種でクラッシュしてしまった可能性がある。

https://developer.android.com/sdk/api_diff/s-beta1-incr/changes/android.content.res.TypedArray