### PR TITLE
Metaが更新されない問題を修正しました

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/instance/db/MetaDTO.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/instance/db/MetaDTO.kt
@@ -1,10 +1,8 @@
 package jp.panta.misskeyandroidclient.model.instance.db
 
 import androidx.room.Entity
-import androidx.room.Ignore
 import androidx.room.PrimaryKey
 import com.google.gson.annotations.SerializedName
-import jp.panta.misskeyandroidclient.model.emoji.Emoji
 import jp.panta.misskeyandroidclient.model.instance.Meta
 
 @Entity(tableName = "meta_table")

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/instance/db/RoomMetaRepository.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/instance/db/RoomMetaRepository.kt
@@ -1,5 +1,6 @@
 package jp.panta.misskeyandroidclient.model.instance.db
 
+import android.util.Log
 import jp.panta.misskeyandroidclient.model.DataBase
 import jp.panta.misskeyandroidclient.model.instance.Meta
 import jp.panta.misskeyandroidclient.model.instance.MetaRepository
@@ -13,8 +14,9 @@ class RoomMetaRepository(
 ) : MetaRepository {
 
     override suspend fun add(meta: Meta): Meta {
-
+        Log.d("RoomMetaRepository", "metaの更新があった")
         return database.runInTransaction<Meta>{
+            metaDAO.delete(MetaDTO(meta))
             metaDAO.insert(MetaDTO(meta))
             val emojiDTOList = meta.emojis?.map{
                 EmojiDTO(it, meta.uri)

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/instance/db/RoomMetaRepository.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/instance/db/RoomMetaRepository.kt
@@ -1,6 +1,5 @@
 package jp.panta.misskeyandroidclient.model.instance.db
 
-import android.util.Log
 import jp.panta.misskeyandroidclient.model.DataBase
 import jp.panta.misskeyandroidclient.model.instance.Meta
 import jp.panta.misskeyandroidclient.model.instance.MetaRepository

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/instance/db/RoomMetaRepository.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/instance/db/RoomMetaRepository.kt
@@ -14,7 +14,6 @@ class RoomMetaRepository(
 ) : MetaRepository {
 
     override suspend fun add(meta: Meta): Meta {
-        Log.d("RoomMetaRepository", "metaの更新があった")
         return database.runInTransaction<Meta>{
             metaDAO.delete(MetaDTO(meta))
             metaDAO.insert(MetaDTO(meta))


### PR DESCRIPTION
#434 
## したこと
アプリ初回起動時、アカウント切り替え時、アカウント追加、削除時に
Metaを再フェッチしてキャッシュを更新する処理を追加しました。

## 確認事項
- 起動時にMetaがネットワークから取得されていること
- データベース上の絵文字が全て更新されている
- 絵文字が削除されていた場合全てのデータベース上の絵文字が削除されている