### PR TITLE
背景画像を設定することができない問題を修正

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/MainActivity.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/MainActivity.kt
@@ -33,7 +33,6 @@ import jp.panta.misskeyandroidclient.databinding.NavHeaderMainBinding
 import jp.panta.misskeyandroidclient.model.TaskState
 import jp.panta.misskeyandroidclient.model.account.Account
 import jp.panta.misskeyandroidclient.model.account.AccountStore
-import jp.panta.misskeyandroidclient.model.core.ConnectionStatus
 import jp.panta.misskeyandroidclient.model.notes.Note
 import jp.panta.misskeyandroidclient.model.settings.SettingStore
 import jp.panta.misskeyandroidclient.model.streaming.stateEvent
@@ -74,8 +73,6 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var mBottomNavigationAdapter: MainBottomNavigationAdapter
 
-    private var mSettingStore: SettingStore? = null
-
     private val mBackPressedDelegate = DoubleBackPressedFinishDelegate()
 
     private val logger: Logger by lazy {
@@ -86,6 +83,9 @@ class MainActivity : AppCompatActivity() {
 
     @Inject
     lateinit var accountStore: AccountStore
+
+    @Inject
+    lateinit var settingStore: SettingStore
 
     @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -443,23 +443,14 @@ class MainActivity : AppCompatActivity() {
             menu.findItem(R.id.action_notification),
             menu.findItem(R.id.action_search)
         ).forEach {
-            it.isVisible = getSettingStore().isClassicUI
+            it.isVisible = settingStore.isClassicUI
         }
 
         //setMenuTint(menu)
         return true
     }
 
-    private fun getSettingStore(): SettingStore {
-        val store: SettingStore = mSettingStore ?: SettingStore(
-            getSharedPreferences(
-                getPreferenceName(),
-                Context.MODE_PRIVATE
-            )
-        )
-        mSettingStore = store
-        return store
-    }
+
 
     @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -494,12 +485,7 @@ class MainActivity : AppCompatActivity() {
 
 
     private fun setBackgroundImage() {
-        val path = SettingStore(
-            getSharedPreferences(
-                getPreferenceName(),
-                Context.MODE_PRIVATE
-            )
-        ).backgroundImagePath
+        val path = settingStore.backgroundImagePath
         Glide.with(this)
             .load(path)
             .into(binding.appBarMain.contentMain.backgroundImage)
@@ -510,12 +496,12 @@ class MainActivity : AppCompatActivity() {
         invalidateOptionsMenu()
         binding.setSimpleEditor()
 
-        binding.appBarMain.bottomNavigation.visibility = if (getSettingStore().isClassicUI) {
+        binding.appBarMain.bottomNavigation.visibility = if (settingStore.isClassicUI) {
             View.GONE
         } else {
             View.VISIBLE
         }
-        if (getSettingStore().isClassicUI) {
+        if (settingStore.isClassicUI) {
             mBottomNavigationAdapter.setCurrentFragment(R.id.navigation_home)
         }
     }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/NoteEditorActivity.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/NoteEditorActivity.kt
@@ -441,11 +441,8 @@ class NoteEditorActivity : AppCompatActivity(), EmojiSelection {
     @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
     private fun showDriveFileSelector() {
         val selectedSize = mViewModel.state.value.totalFilesCount
-
-        val miCore = applicationContext as MiCore
         //Directoryは既に選択済みのファイルの数も含めてしまうので選択済みの数も合わせる
         val selectableMaxSize = mViewModel.maxFileCount.value - selectedSize
-        Log.d("", "選択済みのサイズ:$selectedSize")
         val intent = Intent(this, DriveActivity::class.java)
             .putExtra(DriveActivity.EXTRA_INT_SELECTABLE_FILE_MAX_SIZE, selectableMaxSize)
             .putExtra(DriveActivity.EXTRA_ACCOUNT_ID, accountStore.currentAccount?.accountId)
@@ -460,7 +457,6 @@ class NoteEditorActivity : AppCompatActivity(), EmojiSelection {
     }
 
     private fun requestPermission() {
-        //val permissionCheck = ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)
         if (!checkPermission()) {
             requestReadStoragePermissionResult.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
         }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/drive/viewmodel/file/FileViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/drive/viewmodel/file/FileViewModel.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.*
 /**
  * 選択状態とFileの読み込み＆表示を担当する
  */
-@ExperimentalCoroutinesApi
 class FileViewModel(
     private val currentAccountWatcher: CurrentAccountWatcher,
     private val miCore: MiCore,
@@ -32,9 +31,10 @@ class FileViewModel(
         it.selectedFilePropertyIds?.selectedIds
     }
 
-    @ExperimentalCoroutinesApi
+    @OptIn(ExperimentalCoroutinesApi::class)
     private val account = currentAccountWatcher.account.shareIn(viewModelScope, SharingStarted.Eagerly, replay = 1)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     val state = miCore.getFilePropertyDataSource().state.flatMapLatest { state ->
         filePropertiesPagingStore.state.map { pageable ->
             pageable.convert {

--- a/app/src/main/java/jp/panta/misskeyandroidclient/util/ColorUtil.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/util/ColorUtil.kt
@@ -1,6 +1,5 @@
 package jp.panta.misskeyandroidclient.util
 
-import android.graphics.Color
 import android.util.Log
 import java.lang.IllegalArgumentException
 

--- a/app/src/main/res/layout/item_note.xml
+++ b/app/src/main/res/layout/item_note.xml
@@ -22,7 +22,7 @@
             app:cardCornerRadius="0dp"
             android:layout_marginTop="0.5dp"
             android:elevation="0dp"
-            app:setCardViewSurfaceColor="@{null}"
+            setCardViewSurfaceColor="@{null}"
     >
         <LinearLayout
                 android:layout_width="match_parent"


### PR DESCRIPTION
Androidのローカルから画像を持ってくると
今後またファイルシステムの仕様が変わり面倒なことになる可能性があったため
Driveから取得した画像を設定するようにすることにしました。