### PR TITLE
アンテナを編集画面から削除した時クラッシュする問題を修正しました

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/antenna/viewmodel/AntennaEditorViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/antenna/viewmodel/AntennaEditorViewModel.kt
@@ -265,7 +265,9 @@ class AntennaEditorViewModel (
                 )
             }.onSuccess {
                 if(it.isSuccessful) {
-                    antennaRemovedEvent.event = Unit
+                    withContext(Dispatchers.Main) {
+                        antennaRemovedEvent.event = Unit
+                    }
                 }
             }
         }


### PR DESCRIPTION
## したこと
Mainスレッドで実行しないといけないことを
IOスレッドで実行してしまっていたためクラッシュしていたのを
withContextを使ってMainスレッドに切り替えるようにしてクラッシュしないようにしました。