### PR TITLE
ノート詳細画面に「ブラウザで表示」するためのボタンを追加しました

### DIFF
--- a/app/src/main/res/layout/activity_user_detail.xml
+++ b/app/src/main/res/layout/activity_user_detail.xml
@@ -50,7 +50,7 @@
                                 android:id="@+id/showRemoteUser"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:text="@string/view_in_browswer"
+                                android:text="@string/view_in_browser"
                                 style="@style/Widget.MaterialComponents.Button.TextButton"
                                 />
                     </LinearLayout>

--- a/app/src/main/res/layout/fragment_note_detail.xml
+++ b/app/src/main/res/layout/fragment_note_detail.xml
@@ -4,7 +4,7 @@
             xmlns:app="http://schemas.android.com/apk/res-auto"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
-        <ScrollView
+        <androidx.core.widget.NestedScrollView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
             <LinearLayout
@@ -27,6 +27,6 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
             </LinearLayout>
-        </ScrollView>
+        </androidx.core.widget.NestedScrollView>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_note_detail.xml
+++ b/app/src/main/res/layout/fragment_note_detail.xml
@@ -4,14 +4,29 @@
             xmlns:app="http://schemas.android.com/apk/res-auto"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
-
-        <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/notes_view"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+        <ScrollView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+            <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+                <Button
+                        android:id="@+id/showInBrowser"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/view_in_browser"
+                        style="@style/Widget.MaterialComponents.Button.TextButton"
+                        />
+                <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/notes_view"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+            </LinearLayout>
+        </ScrollView>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -387,5 +387,5 @@
     <string name="delete_nickname">ニックネームを削除</string>
     <string name="suggested_emojis">絵文字の候補</string>
     <string name="the_remote_emoji_does_not_exist_in_this_instance">そのリモート絵文字はこのインスタンスには存在しません。</string>
-    <string name="view_in_browswer">ブラウザで表示</string>
+    <string name="view_in_browser">ブラウザで表示</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -381,6 +381,6 @@
     <string name="delete_nickname">Delete nickname</string>
     <string name="suggested_emojis">Suggested Emojis</string>
     <string name="the_remote_emoji_does_not_exist_in_this_instance">此实例中不存在远程表情符号。</string>
-    <string name="view_in_browswer">在浏览器中查看</string>
+    <string name="view_in_browser">在浏览器中查看</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,5 +385,5 @@
     <string name="delete_nickname">Delete nickname</string>
     <string name="suggested_emojis">Suggested Emojis</string>
     <string name="the_remote_emoji_does_not_exist_in_this_instance">The remote emoji does not exist in this instance.</string>
-    <string name="view_in_browswer">View in browser</string>
+    <string name="view_in_browser">View in browser</string>
 </resources>


### PR DESCRIPTION
## やったこと
ノートの詳細画面上部にブラウザでノートを表示するためのボタンを表示するようにしました。

## 動作確認
URLをクリックして適切なインテントを発行されること

## 関連リンク
https://github.com/pantasystem/MisskeyAndroidClient/issues/467


