### PR TITLE
ユーザータイムラインを自動更新できるようにしました

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/streaming/channel/ChannelAPI.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/streaming/channel/ChannelAPI.kt
@@ -213,9 +213,3 @@ class ChannelAPI(
     }
 
 }
-
-fun ChannelAPI.connectUserTimeline(userId: String): Flow<ChannelBody> {
-    return this.connect(ChannelAPI.Type.Global).filter {
-        it is ChannelBody.ReceiveNote && it.body.userId == userId
-    }
-}

--- a/app/src/main/java/jp/panta/misskeyandroidclient/streaming/channel/ChannelAPI.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/streaming/channel/ChannelAPI.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.*
@@ -211,4 +212,10 @@ class ChannelAPI(
 
     }
 
+}
+
+fun ChannelAPI.connectUserTimeline(userId: String): Flow<ChannelBody> {
+    return this.connect(ChannelAPI.Type.Global).filter {
+        it is ChannelBody.ReceiveNote && it.body.userId == userId
+    }
 }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/streaming/channel/user_timeline_extenstion.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/streaming/channel/user_timeline_extenstion.kt
@@ -1,0 +1,12 @@
+package jp.panta.misskeyandroidclient.streaming.channel
+
+import jp.panta.misskeyandroidclient.streaming.ChannelBody
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+
+
+fun ChannelAPI.connectUserTimeline(userId: String): Flow<ChannelBody> {
+    return this.connect(ChannelAPI.Type.Global).filter {
+        it is ChannelBody.ReceiveNote && it.body.userId == userId
+    }
+}

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/TimelineViewModel.kt
@@ -10,6 +10,7 @@ import jp.panta.misskeyandroidclient.model.notes.*
 import jp.panta.misskeyandroidclient.model.settings.SettingStore
 import jp.panta.misskeyandroidclient.streaming.ChannelBody
 import jp.panta.misskeyandroidclient.streaming.channel.ChannelAPI
+import jp.panta.misskeyandroidclient.streaming.channel.connectUserTimeline
 import jp.panta.misskeyandroidclient.util.BodyLessResponse
 import jp.panta.misskeyandroidclient.viewmodel.MiCore
 import jp.panta.misskeyandroidclient.ui.notes.viewmodel.favorite.FavoriteNotePagingStore
@@ -83,6 +84,7 @@ class TimelineViewModel(
                     || pageable is Pageable.HomeTimeline
                     || pageable is Pageable.UserListTimeline
                     || pageable is Pageable.Antenna
+                    || pageable is Pageable.UserTimeline
         }.flatMapLatest { account ->
             when (pageable) {
                 is Pageable.GlobalTimeline -> {
@@ -106,6 +108,10 @@ class TimelineViewModel(
                 is Pageable.Antenna -> {
                     miCore.getChannelAPI(account)
                         .connect(ChannelAPI.Type.Antenna(antennaId = pageable.antennaId))
+                }
+                is Pageable.UserTimeline -> {
+                    miCore.getChannelAPI(account)
+                        .connectUserTimeline(pageable.userId)
                 }
                 else -> throw IllegalStateException("Global, Hybrid, Local, Homeは以外のStreamは対応していません。")
             }


### PR DESCRIPTION
## やったこと
GlobalTimelineのStreamingを流用して、
ユーザータイムラインの表示状態を自動で更新できるようにしました。

## 動作確認
ユーザータイムラインを表示している時に
自動的にそのユーザーの投稿が流れてくること



## 関連リンク
Closed #473 
