### PR TITLE
チャンネルタイムラインを正常に表示できなかった問題を修正しました

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/account/page/Pageable.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/account/page/Pageable.kt
@@ -93,6 +93,7 @@ sealed class Pageable : Serializable{
     ) : Pageable(), UntilPaginate, SincePaginate {
         override fun toParams(): PageParams {
             return PageParams(
+                PageType.CHANNEL_TIMELINE,
                 channelId = channelId
             )
         }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/settings/activities/PageSettingActivity.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/settings/activities/PageSettingActivity.kt
@@ -54,42 +54,53 @@ class PageSettingActivity : AppCompatActivity() {
         binding.pagesView.adapter = pagesAdapter
         binding.pagesView.layoutManager = LinearLayoutManager(this)
 
-        mPageSettingViewModel.selectedPages.observe(this, {
+        mPageSettingViewModel.selectedPages.observe(this) {
             Log.d("PageSettingActivity", "選択済みページが更新された")
             pagesAdapter.submitList(it)
-        })
+        }
 
         binding.addPageButton.setOnClickListener {
             SelectPageToAddDialog().show(supportFragmentManager, "Activity")
         }
 
-        mPageSettingViewModel.pageOnActionEvent.observe(this, {
+        mPageSettingViewModel.pageOnActionEvent.observe(this) {
             PageSettingActionDialog().show(supportFragmentManager, "PSA")
-        })
+        }
 
-        mPageSettingViewModel.pageOnUpdateEvent.observe(this, {
+        mPageSettingViewModel.pageOnUpdateEvent.observe(this) {
             EditTabNameDialog().show(supportFragmentManager, "ETD")
-        })
+        }
 
-        mPageSettingViewModel.pageAddedEvent.observe(this, { pt ->
-            when(pt){
-                PageType.SEARCH, PageType.SEARCH_HASH -> startActivity(Intent(this, SearchActivity::class.java))
+        mPageSettingViewModel.pageAddedEvent.observe(this) { pt ->
+            when (pt) {
+                PageType.SEARCH, PageType.SEARCH_HASH -> startActivity(
+                    Intent(
+                        this,
+                        SearchActivity::class.java
+                    )
+                )
                 PageType.USER -> {
-                    val intent = SearchAndSelectUserActivity.newIntent(this, selectableMaximumSize = 1)
+                    val intent =
+                        SearchAndSelectUserActivity.newIntent(this, selectableMaximumSize = 1)
                     startActivityForResult(intent, SEARCH_AND_SELECT_USER_RESULT_CODE)
                 }
                 PageType.USER_LIST -> startActivity(Intent(this, ListListActivity::class.java))
                 PageType.DETAIL -> startActivity(Intent(this, SearchActivity::class.java))
                 PageType.ANTENNA -> startActivity(Intent(this, AntennaListActivity::class.java))
                 PageType.USERS_GALLERY_POSTS -> {
-                    val intent = SearchAndSelectUserActivity.newIntent(this, selectableMaximumSize = 1)
+                    val intent =
+                        SearchAndSelectUserActivity.newIntent(this, selectableMaximumSize = 1)
                     startActivityForResult(intent, SEARCH_AND_SELECT_USER_FOR_GALLERY_CODE)
                 }
-                else ->{
+                PageType.CHANNEL_TIMELINE -> {
+                    val intent = Intent(this, ChannelActivity::class.java)
+                    startActivity(intent)
+                }
+                else -> {
                     // auto add
                 }
             }
-        })
+        }
 
     }
 

--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/account/page/PageableChannelTimelineTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/account/page/PageableChannelTimelineTest.kt
@@ -11,6 +11,7 @@ class PageableChannelTimelineTest {
         val pageable = Pageable.ChannelTimeline(channelId = "channelId")
         assertNotNull(pageable.toParams().channelId)
         assertEquals("channelId", pageable.toParams().channelId)
+        assertEquals(PageType.CHANNEL_TIMELINE, pageable.toParams().type)
     }
 
     @Test


### PR DESCRIPTION
Tab設定画面からChannel一覧画面へ遷移できるようにしました。

## やったこと
Page(Tab)を保存する時にPageTypeをHomeにして保存してしまっていたため
このような問題が発生していました。
これを正しいPageTypeであるCHANNEL_TIMELINEが入るように修正しました。

## 動作確認
CIが通ること
実機で動作して、チャンネルタイムラインを表示することができること。

## 備考


## 関連リンク
Closed #486 
Closed #483 

