### PR TITLE
ホーム画面のFabを切り替えるようにしました

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/MainActivity.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/MainActivity.kt
@@ -33,6 +33,7 @@ import jp.panta.misskeyandroidclient.model.CreateNoteTaskExecutor
 import jp.panta.misskeyandroidclient.model.TaskState
 import jp.panta.misskeyandroidclient.model.account.Account
 import jp.panta.misskeyandroidclient.model.account.AccountStore
+import jp.panta.misskeyandroidclient.model.channel.Channel
 import jp.panta.misskeyandroidclient.model.notes.Note
 import jp.panta.misskeyandroidclient.model.settings.SettingStore
 import jp.panta.misskeyandroidclient.model.streaming.stateEvent
@@ -130,7 +131,8 @@ class MainActivity : AppCompatActivity() {
         }
 
         binding.appBarMain.fab.setOnClickListener {
-            when (currentPageableTimelineViewModel.currentType.value.suitableType()) {
+
+            when (val type = currentPageableTimelineViewModel.currentType.value.suitableType()) {
                 is SuitableType.Other -> {
                     startActivity(Intent(this, NoteEditorActivity::class.java))
                 }
@@ -140,7 +142,13 @@ class MainActivity : AppCompatActivity() {
                     startActivity(intent)
                 }
                 is SuitableType.Channel -> {
-                    startActivity(Intent(this, NoteEditorActivity::class.java))
+                    val accountId = accountStore.currentAccountId!!
+                    startActivity(
+                        NoteEditorActivity.newBundle(
+                            this,
+                            channelId = Channel.Id(accountId, type.channelId)
+                        )
+                    )
                 }
             }
         }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/NoteEditorActivity.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/NoteEditorActivity.kt
@@ -24,6 +24,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import jp.panta.misskeyandroidclient.databinding.ActivityNoteEditorBinding
 import jp.panta.misskeyandroidclient.databinding.ViewNoteEditorToolbarBinding
 import jp.panta.misskeyandroidclient.model.account.AccountStore
+import jp.panta.misskeyandroidclient.model.channel.Channel
 import jp.panta.misskeyandroidclient.model.confirm.ConfirmCommand
 import jp.panta.misskeyandroidclient.model.confirm.ResultType
 import jp.panta.misskeyandroidclient.model.core.ConnectionStatus
@@ -68,13 +69,15 @@ class NoteEditorActivity : AppCompatActivity(), EmojiSelection {
 
         private const val CONFIRM_SAVE_AS_DRAFT_OR_DELETE = "confirm_save_as_draft_or_delete"
         private const val EXTRA_MENTIONS = "EXTRA_MENTIONS"
+        private const val EXTRA_CHANNEL_ID = "EXTRA_CHANNEL_ID"
 
         fun newBundle(
             context: Context,
             replyTo: Note.Id? = null,
             quoteTo: Note.Id? = null,
             draftNote: DraftNote? = null,
-            mentions: List<String>? = null
+            mentions: List<String>? = null,
+            channelId: Channel.Id? = null,
         ): Intent {
             return Intent(context, NoteEditorActivity::class.java).apply {
                 replyTo?.let {
@@ -94,6 +97,11 @@ class NoteEditorActivity : AppCompatActivity(), EmojiSelection {
 
                 mentions?.let {
                     putExtra(EXTRA_MENTIONS, it.toTypedArray())
+                }
+
+                channelId?.let {
+                    putExtra(EXTRA_CHANNEL_ID, it.channelId)
+                    putExtra(EXTRA_ACCOUNT_ID, it.accountId)
                 }
 
             }
@@ -160,6 +168,10 @@ class NoteEditorActivity : AppCompatActivity(), EmojiSelection {
             Note.Id(accountId, it)
         }
 
+        val channelId = intent.getStringExtra(EXTRA_CHANNEL_ID)?.let {
+            requireNotNull(accountId)
+            Channel.Id(accountId, it)
+        }
 
         val draftNote: DraftNote? = intent.getSerializableExtra(EXTRA_DRAFT_NOTE) as? DraftNote?
 
@@ -217,6 +229,7 @@ class NoteEditorActivity : AppCompatActivity(), EmojiSelection {
         }
         mViewModel.setReplyTo(replyToNoteId)
         mViewModel.setRenoteTo(quoteToNoteId)
+        mViewModel.setChannelId(channelId)
         if (draftNote != null) {
             mViewModel.setDraftNote(draftNote)
         }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/file/File.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/file/File.kt
@@ -13,7 +13,13 @@ sealed interface AppFile : JSerializable {
         val isSensitive: Boolean,
         val folderId: String?,
         val id: Long = 0,
-    ) : AppFile
+    ) : AppFile {
+        fun isAttributeSame(file: Local): Boolean {
+            return file.name == name
+                    && file.path == path
+                    && file.type == type
+        }
+    }
 
     data class Remote(
         val id: FileProperty.Id,

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/NoteEditingState.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/NoteEditingState.kt
@@ -43,8 +43,8 @@ data class NoteEditingState(
         get() = this.visibility.isLocalOnly()
 
 
-    fun setDraftNote(draftNote: DraftNote?) : NoteEditingState {
-        return draftNote?.toNoteEditingState()?: this
+    fun setDraftNote(draftNote: DraftNote?): NoteEditingState {
+        return draftNote?.toNoteEditingState() ?: this
     }
 
     fun changeRenoteId(renoteId: Note.Id?): NoteEditingState {
@@ -59,20 +59,20 @@ data class NoteEditingState(
         )
     }
 
-    fun checkValidate(textMaxLength: Int = 3000, maxFileCount: Int = 4) : Boolean {
-        if(this.files.size > maxFileCount) {
+    fun checkValidate(textMaxLength: Int = 3000, maxFileCount: Int = 4): Boolean {
+        if (this.files.size > maxFileCount) {
             return false
         }
 
-        if((this.text?.codePointCount(0, this.text.length) ?: 0) > textMaxLength) {
+        if ((this.text?.codePointCount(0, this.text.length) ?: 0) > textMaxLength) {
             return false
         }
 
-        if(this.renoteId != null) {
+        if (this.renoteId != null) {
             return true
         }
 
-        if(this.poll != null && this.poll.checkValidate()) {
+        if (this.poll != null && this.poll.checkValidate()) {
             return true
         }
 
@@ -82,13 +82,13 @@ data class NoteEditingState(
                 )
     }
 
-    fun changeText(text: String) : NoteEditingState {
+    fun changeText(text: String): NoteEditingState {
         return this.copy(
             text = text
         )
     }
 
-    fun addMentionUserNames(userNames: List<String>, pos: Int) : AddMentionResult {
+    fun addMentionUserNames(userNames: List<String>, pos: Int): AddMentionResult {
         val mentionBuilder = StringBuilder()
         userNames.forEachIndexed { index, userName ->
             if (index < userNames.size - 1) {
@@ -104,13 +104,13 @@ data class NoteEditingState(
         return AddMentionResult(pos + mentionBuilder.length, copy(text = builder.toString()))
     }
 
-    fun changeCw(text: String?) : NoteEditingState {
+    fun changeCw(text: String?): NoteEditingState {
         return this.copy(
             cw = text
         )
     }
 
-    fun addFile(file: AppFile) : NoteEditingState {
+    fun addFile(file: AppFile): NoteEditingState {
         return this.copy(
             files = this.files.toMutableList().apply {
                 add(file)
@@ -118,7 +118,7 @@ data class NoteEditingState(
         )
     }
 
-    fun removeFile(file: AppFile) : NoteEditingState {
+    fun removeFile(file: AppFile): NoteEditingState {
         return this.copy(
             files = this.files.toMutableList().apply {
                 remove(file)
@@ -126,33 +126,33 @@ data class NoteEditingState(
         )
     }
 
-    fun changePollExpiresAt(expiresAt: PollExpiresAt) : NoteEditingState{
+    fun changePollExpiresAt(expiresAt: PollExpiresAt): NoteEditingState {
         return this.copy(
             poll = this.poll?.copy(expiresAt = expiresAt)
         )
     }
 
-    fun setAccount(account: Account?) : NoteEditingState{
-        if(author == null) {
+    fun setAccount(account: Account?): NoteEditingState {
+        if (author == null) {
             return this.copy(
                 author = account
             )
         }
-        if(account == null) {
+        if (account == null) {
             throw IllegalArgumentException("現在の状態に未指定のAccountを指定することはできません")
         }
-        if(files.any { it is AppFile.Remote }) {
+        if (files.any { it is AppFile.Remote }) {
             throw IllegalArgumentException("リモートファイル指定時にアカウントを変更することはできません(files)。")
         }
-        if(!(replyId == null || author.instanceDomain == account.instanceDomain)) {
+        if (!(replyId == null || author.instanceDomain == account.instanceDomain)) {
             throw IllegalArgumentException("異なるインスタンスドメインのアカウントを切り替えることはできません(replyId)。")
         }
 
-        if(!(renoteId == null || author.instanceDomain == account.instanceDomain)) {
+        if (!(renoteId == null || author.instanceDomain == account.instanceDomain)) {
             throw IllegalArgumentException("異なるインスタンスドメインのアカウントを切り替えることはできません(renoteId)。")
         }
 
-        if(visibility is Visibility.Specified
+        if (visibility is Visibility.Specified
             && (visibility.visibleUserIds.isNotEmpty()
                     || author.instanceDomain == account.instanceDomain)
         ) {
@@ -164,18 +164,18 @@ data class NoteEditingState(
             files = files,
             replyId = replyId?.copy(accountId = account.accountId),
             renoteId = renoteId?.copy(accountId = account.accountId),
-            visibility = if(visibility is Visibility.Specified) {
+            visibility = if (visibility is Visibility.Specified) {
                 visibility.copy(visibleUserIds = visibility.visibleUserIds.map {
                     it.copy(accountId = account.accountId)
                 })
-            }else{
+            } else {
                 visibility
             }
         )
 
     }
 
-    fun removePollChoice(id: UUID) : NoteEditingState {
+    fun removePollChoice(id: UUID): NoteEditingState {
         return this.copy(
             poll = this.poll?.let {
                 it.copy(
@@ -187,7 +187,7 @@ data class NoteEditingState(
         )
     }
 
-    fun addPollChoice() : NoteEditingState {
+    fun addPollChoice(): NoteEditingState {
         return this.copy(
             poll = this.poll?.let {
                 it.copy(
@@ -201,16 +201,16 @@ data class NoteEditingState(
         )
     }
 
-    fun updatePollChoice(id: UUID, text: String) : NoteEditingState {
+    fun updatePollChoice(id: UUID, text: String): NoteEditingState {
         return this.copy(
             poll = this.poll?.let {
                 it.copy(
                     choices = it.choices.map { choice ->
-                        if(choice.id == id) {
+                        if (choice.id == id) {
                             choice.copy(
                                 text = text
                             )
-                        }else{
+                        } else {
                             choice
                         }
                     }
@@ -219,22 +219,38 @@ data class NoteEditingState(
         )
     }
 
-    fun toggleCw() : NoteEditingState {
+    fun toggleCw(): NoteEditingState {
         return this.copy(
-            cw = if(this.hasCw) null else ""
+            cw = if (this.hasCw) null else ""
         )
     }
 
-    fun togglePoll() : NoteEditingState {
+    fun togglePoll(): NoteEditingState {
         return this.copy(
-            poll = if(poll == null) PollEditingState(emptyList(), false) else null
+            poll = if (poll == null) PollEditingState(emptyList(), false) else null
         )
     }
 
-    fun clear() : NoteEditingState {
+    fun clear(): NoteEditingState {
         return NoteEditingState(author = this.author)
     }
 
+    fun toggleFileSensitiveStatus(appFile: AppFile.Local): NoteEditingState {
+        return copy(
+            files = files.map {
+                if (it === appFile
+                    || (it is AppFile.Local
+                            && it.path == appFile.path
+                            && it.type == appFile.type
+                            && it.folderId == appFile.folderId)
+                ) {
+                    appFile.copy(isSensitive = !appFile.isSensitive)
+                } else {
+                    it
+                }
+            }
+        )
+    }
 }
 
 sealed interface PollExpiresAt {
@@ -242,14 +258,14 @@ sealed interface PollExpiresAt {
     data class DateAndTime(val expiresAt: Instant) : PollExpiresAt
 
     fun asDate(): Date? {
-        return this.expiresAt()?.toEpochMilliseconds()?.let{
+        return this.expiresAt()?.toEpochMilliseconds()?.let {
             Date(it)
         }
     }
 }
 
-fun PollExpiresAt.expiresAt() : Instant? {
-    return when(this) {
+fun PollExpiresAt.expiresAt(): Instant? {
+    return when (this) {
         is PollExpiresAt.Infinity -> null
         is PollExpiresAt.DateAndTime -> this.expiresAt
     }
@@ -264,13 +280,13 @@ data class PollEditingState(
     val isExpiresAtDateTime: Boolean
         get() = expiresAt is PollExpiresAt.DateAndTime
 
-    fun checkValidate() : Boolean {
+    fun checkValidate(): Boolean {
         return choices.all {
             it.text.isNotBlank()
         } && this.choices.size >= 2
     }
 
-    fun toggleMultiple() : PollEditingState{
+    fun toggleMultiple(): PollEditingState {
         return this.copy(
             multiple = !this.multiple
         )
@@ -282,14 +298,17 @@ data class PollChoiceState(
     val id: UUID = UUID.randomUUID()
 )
 
-fun DraftNote.toNoteEditingState() : NoteEditingState{
+fun DraftNote.toNoteEditingState(): NoteEditingState {
     return NoteEditingState(
         text = this.text,
         cw = this.cw,
         draftNoteId = this.draftNoteId,
-        visibility = Visibility(type = this.visibility, isLocalOnly = this.localOnly ?: false, visibleUserIds = this.visibleUserIds?.map {
-            User.Id(accountId = accountId, id = it)
-        }),
+        visibility = Visibility(
+            type = this.visibility,
+            isLocalOnly = this.localOnly ?: false,
+            visibleUserIds = this.visibleUserIds?.map {
+                User.Id(accountId = accountId, id = it)
+            }),
         viaMobile = this.viaMobile ?: true,
         poll = this.draftPoll?.let {
             PollEditingState(
@@ -300,7 +319,7 @@ fun DraftNote.toNoteEditingState() : NoteEditingState{
                     PollExpiresAt.DateAndTime(
                         Instant.fromEpochMilliseconds(ex)
                     )
-                }?: PollExpiresAt.Infinity,
+                } ?: PollExpiresAt.Infinity,
                 multiple = it.multiple
             )
         },
@@ -311,11 +330,11 @@ fun DraftNote.toNoteEditingState() : NoteEditingState{
             Note.Id(accountId = accountId, noteId = it)
         },
         files = this.files?.map {
-            if(it.isRemoteFile) {
+            if (it.isRemoteFile) {
                 AppFile.Remote(
                     it.remoteFileId!!
                 )
-            }else{
+            } else {
                 AppFile.Local(
                     name = it.name,
                     isSensitive = it.isSensitive ?: false,
@@ -332,7 +351,7 @@ fun DraftNote.toNoteEditingState() : NoteEditingState{
     )
 }
 
-fun PollEditingState.toCreatePoll() : CreatePoll {
+fun PollEditingState.toCreatePoll(): CreatePoll {
     return CreatePoll(
         choices = this.choices.map {
             it.text
@@ -342,7 +361,7 @@ fun PollEditingState.toCreatePoll() : CreatePoll {
     )
 }
 
-fun PollEditingState.toDraftPoll() : DraftPoll {
+fun PollEditingState.toDraftPoll(): DraftPoll {
     return DraftPoll(
         choices = this.choices.map {
             it.text

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/NoteEditingState.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/NoteEditingState.kt
@@ -68,6 +68,10 @@ data class NoteEditingState(
             return false
         }
 
+        if (channelId != null && visibility != Visibility.Public(true)) {
+            return false
+        }
+
         if (this.renoteId != null) {
             return true
         }
@@ -245,6 +249,29 @@ data class NoteEditingState(
                 }
             }
         )
+    }
+
+    fun setChannelId(channelId: Channel.Id?): NoteEditingState {
+        return copy(
+            visibility = if (channelId == null) visibility else Visibility.Public(true),
+            channelId = channelId
+        )
+    }
+
+    fun setChangeVisibility(visibility: Visibility): NoteEditingState {
+        if (channelId == null) {
+            return copy(
+                visibility = visibility
+            )
+        }
+
+        if (visibility != Visibility.Public(true)) {
+            return copy(
+                visibility = Visibility.Public(true)
+            )
+        }
+
+        return this
     }
 }
 

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/NoteEditingState.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/NoteEditingState.kt
@@ -238,12 +238,7 @@ data class NoteEditingState(
     fun toggleFileSensitiveStatus(appFile: AppFile.Local): NoteEditingState {
         return copy(
             files = files.map {
-                if (it === appFile
-                    || (it is AppFile.Local
-                            && it.path == appFile.path
-                            && it.type == appFile.type
-                            && it.folderId == appFile.folderId)
-                ) {
+                if (it === appFile || it is AppFile.Local && it.isAttributeSame(appFile)) {
                     appFile.copy(isSensitive = !appFile.isSensitive)
                 } else {
                     it

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/NoteEditingState.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/NoteEditingState.kt
@@ -258,7 +258,7 @@ data class NoteEditingState(
         )
     }
 
-    fun setChangeVisibility(visibility: Visibility): NoteEditingState {
+    fun setVisibility(visibility: Visibility): NoteEditingState {
         if (channelId == null) {
             return copy(
                 visibility = visibility

--- a/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/impl/NoteRepositoryImpl.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/model/notes/impl/NoteRepositoryImpl.kt
@@ -70,7 +70,10 @@ class NoteRepositoryImpl @Inject constructor(
         createNote.draftNoteId?.let {
             draftNoteDao.deleteDraftNote(createNote.author.accountId, draftNoteId = it)
         }
-        settingStore.setNoteVisibility(createNote)
+
+        if (createNote.channelId == null) {
+            settingStore.setNoteVisibility(createNote)
+        }
 
         return noteDataSourceAdder.addNoteDtoToDataSource(createNote.author, noteDTO)
 

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/gallery/viewmodel/GalleryEditorViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/gallery/viewmodel/GalleryEditorViewModel.kt
@@ -4,24 +4,23 @@ import androidx.lifecycle.*
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.panta.misskeyandroidclient.Logger
 import jp.panta.misskeyandroidclient.model.CreateGalleryTaskExecutor
-import jp.panta.misskeyandroidclient.model.TaskExecutor
 import jp.panta.misskeyandroidclient.model.account.Account
 import jp.panta.misskeyandroidclient.model.account.AccountRepository
 import jp.panta.misskeyandroidclient.model.drive.DriveFileRepository
 import jp.panta.misskeyandroidclient.model.drive.FileProperty
 import jp.panta.misskeyandroidclient.model.drive.FilePropertyDataSource
 import jp.panta.misskeyandroidclient.model.file.AppFile
-import jp.panta.misskeyandroidclient.model.gallery.*
-import jp.panta.misskeyandroidclient.viewmodel.MiCore
+import jp.panta.misskeyandroidclient.model.gallery.CreateGalleryPost
+import jp.panta.misskeyandroidclient.model.gallery.GalleryPost
+import jp.panta.misskeyandroidclient.model.gallery.GalleryRepository
+import jp.panta.misskeyandroidclient.model.gallery.toTask
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.io.Serializable
-import javax.inject.Inject
 
 
 sealed class EditType : Serializable{
@@ -48,7 +47,7 @@ class GalleryEditorViewModel @AssistedInject constructor(
     interface ViewModelAssistedFactory {
         fun create(type: EditType): GalleryEditorViewModel
     }
-    companion object;
+    companion object
 
     val logger = loggerFactory.create("GalleryEditorVM")
 

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/editor/NoteEditorViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/editor/NoteEditorViewModel.kt
@@ -33,12 +33,12 @@ class NoteEditorViewModel @Inject constructor(
     private val draftNoteDao: DraftNoteDao,
     loggerFactory: Logger.Factory,
     private val miCore: MiCore,
-    val noteRepository: NoteRepository,
-    val filePropertyDataSource: FilePropertyDataSource,
-    val metaRepository: MetaRepository,
-    val driveFileRepository: DriveFileRepository,
-    val accountStore: AccountStore,
-    val createNoteTaskExecutor: CreateNoteTaskExecutor
+    private val noteRepository: NoteRepository,
+    private val filePropertyDataSource: FilePropertyDataSource,
+    private val metaRepository: MetaRepository,
+    private val driveFileRepository: DriveFileRepository,
+    private val accountStore: AccountStore,
+    private val createNoteTaskExecutor: CreateNoteTaskExecutor
 ) : ViewModel() {
 
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
@@ -275,17 +275,7 @@ class NoteEditorViewModel @Inject constructor(
     fun toggleNsfw(appFile: AppFile) {
         when (appFile) {
             is AppFile.Local -> {
-                _state.value = state.value.copy(
-                    files = _state.value.files.map {
-                        if (appFile === appFile) {
-                            appFile.copy(
-                                isSensitive = !appFile.isSensitive
-                            )
-                        } else {
-                            appFile
-                        }
-                    }
-                )
+                _state.value = state.value.toggleFileSensitiveStatus(appFile)
             }
             is AppFile.Remote -> {
                 viewModelScope.launch(Dispatchers.IO) {
@@ -444,7 +434,8 @@ class NoteEditorViewModel @Inject constructor(
             },
             reservationPostingAt = _state.value.reservationPostingAt?.toEpochMilliseconds()?.let {
                 Date(it)
-            }
+            },
+            channelId = _state.value.channelId,
         ).apply {
             setDraftNote(this)
         }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/editor/NoteEditorViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/editor/NoteEditorViewModel.kt
@@ -210,9 +210,8 @@ class NoteEditorViewModel @Inject constructor(
 
         accountStore.observeCurrentAccount.filterNotNull().onEach {
             val v = miCore.getSettingStore().getNoteVisibility(it.accountId)
-            _state.value = _state.value.copy(
-                visibility = v
-            )
+            _state.value = _state.value.setVisibility(v)
+
         }.launchIn(viewModelScope + Dispatchers.IO)
 
     }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/editor/NoteEditorViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/editor/NoteEditorViewModel.kt
@@ -7,6 +7,7 @@ import jp.panta.misskeyandroidclient.model.CreateNoteTaskExecutor
 import jp.panta.misskeyandroidclient.model.account.Account
 import jp.panta.misskeyandroidclient.model.account.AccountStore
 import jp.panta.misskeyandroidclient.model.api.Version
+import jp.panta.misskeyandroidclient.model.channel.Channel
 import jp.panta.misskeyandroidclient.model.drive.DriveFileRepository
 import jp.panta.misskeyandroidclient.model.drive.FileProperty
 import jp.panta.misskeyandroidclient.model.drive.FilePropertyDataSource
@@ -355,12 +356,13 @@ class NoteEditorViewModel @Inject constructor(
 
     fun setVisibility(visibility: Visibility) {
         logger.debug("公開範囲がセットされた:$visibility")
-        _state.value = _state.value.copy(
-            visibility = visibility
-        )
+        _state.value = _state.value.setVisibility(visibility)
         this.visibilitySelectedEvent.event = Unit
     }
 
+    fun setChannelId(channelId: Channel.Id?) {
+        _state.value = _state.value.setChannelId(channelId)
+    }
 
     fun toggleReservationAt() {
         _state.value = _state.value.copy(

--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/file/AppFileTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/file/AppFileTest.kt
@@ -1,0 +1,23 @@
+package jp.panta.misskeyandroidclient.model.file
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class AppFileTest {
+
+    @Test
+    fun isAttributeSame() {
+        val file1 = AppFile.Local("test", "/test/test3", "image/jpeg", null, false, null, 0)
+        val file2 = file1.copy()
+        assertTrue(file1.isAttributeSame(file2))
+
+        val file3 = file1.copy(name = "test1")
+        assertFalse(file3.isAttributeSame(file1))
+
+        assertFalse(file1.copy(path = "/test/test").isAttributeSame(file1))
+
+        assertFalse(file1.copy(type = "video/mp4").isAttributeSame(file1))
+        assertTrue(file1.copy(isSensitive = true).isAttributeSame(file1))
+        assertTrue(file1.copy(folderId = "hoge").isAttributeSame(file1))
+    }
+}

--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/notes/NoteEditingStateTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/notes/NoteEditingStateTest.kt
@@ -1,9 +1,11 @@
 package jp.panta.misskeyandroidclient.model.notes
 
 import jp.panta.misskeyandroidclient.model.account.Account
+import jp.panta.misskeyandroidclient.model.channel.Channel
 import jp.panta.misskeyandroidclient.model.drive.FileProperty
 import jp.panta.misskeyandroidclient.model.file.AppFile
 import junit.framework.TestCase
+import org.junit.Test
 
 class NoteEditingStateTest : TestCase() {
 
@@ -246,5 +248,49 @@ class NoteEditingStateTest : TestCase() {
         assertNotSame(expectedFile, updatedState.files[1])
         assertNotSame(expectedFile, updatedState.files[2])
         assertNotSame(expectedFile, updatedState.files[4])
+    }
+
+    fun testSetChannelId() {
+        var state = NoteEditingState(
+            visibility = Visibility.Followers(false)
+        )
+
+        val channelId = Channel.Id(0, "test1")
+        state = state.setChannelId(channelId)
+        assertEquals(channelId, state.channelId)
+
+        assertEquals(Visibility.Public(true), state.visibility)
+    }
+
+
+    fun testCheckValidateWhenHasChannelId() {
+        val channelId = Channel.Id(0, "test1")
+        var state = NoteEditingState(visibility = Visibility.Public(true), channelId = channelId, text = "hoge")
+        assertTrue(state.checkValidate())
+
+        state = state.copy(visibility = Visibility.Public(false))
+        assertFalse(state.checkValidate())
+
+        state = state.copy(visibility = Visibility.Followers(true))
+        assertFalse(state.checkValidate())
+    }
+
+    fun testSetVisibilityWhenSatChannelId() {
+        val channelId = Channel.Id(0, "test1")
+        var state = NoteEditingState(channelId = channelId)
+        state = state.setChangeVisibility(
+            visibility = Visibility.Public(false)
+        )
+        assertEquals(Visibility.Public(true), state.visibility)
+        state = state.setChangeVisibility(Visibility.Followers(true))
+        assertEquals(Visibility.Public(true), state.visibility)
+    }
+
+    fun testSetVisibility() {
+        var state = NoteEditingState()
+        state = state.setChangeVisibility(Visibility.Public(false))
+        assertEquals(Visibility.Public(false), state.visibility)
+        state = state.setChangeVisibility(Visibility.Home(true))
+        assertEquals(Visibility.Home(true), state.visibility)
     }
 }

--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/notes/NoteEditingStateTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/notes/NoteEditingStateTest.kt
@@ -5,7 +5,6 @@ import jp.panta.misskeyandroidclient.model.channel.Channel
 import jp.panta.misskeyandroidclient.model.drive.FileProperty
 import jp.panta.misskeyandroidclient.model.file.AppFile
 import junit.framework.TestCase
-import org.junit.Test
 
 class NoteEditingStateTest : TestCase() {
 
@@ -278,19 +277,19 @@ class NoteEditingStateTest : TestCase() {
     fun testSetVisibilityWhenSatChannelId() {
         val channelId = Channel.Id(0, "test1")
         var state = NoteEditingState(channelId = channelId)
-        state = state.setChangeVisibility(
+        state = state.setVisibility(
             visibility = Visibility.Public(false)
         )
         assertEquals(Visibility.Public(true), state.visibility)
-        state = state.setChangeVisibility(Visibility.Followers(true))
+        state = state.setVisibility(Visibility.Followers(true))
         assertEquals(Visibility.Public(true), state.visibility)
     }
 
     fun testSetVisibility() {
         var state = NoteEditingState()
-        state = state.setChangeVisibility(Visibility.Public(false))
+        state = state.setVisibility(Visibility.Public(false))
         assertEquals(Visibility.Public(false), state.visibility)
-        state = state.setChangeVisibility(Visibility.Home(true))
+        state = state.setVisibility(Visibility.Home(true))
         assertEquals(Visibility.Home(true), state.visibility)
     }
 }

--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/notes/NoteEditingStateTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/notes/NoteEditingStateTest.kt
@@ -227,4 +227,24 @@ class NoteEditingStateTest : TestCase() {
         assertEquals(userNames[0].length + 1 + 0, result.cursorPos)
     }
 
+    fun testToggleFilesSensitive() {
+        val targetFile = AppFile.Local("test", "/test/test2", "image/jpeg", null, false, null, 0)
+        val state = NoteEditingState(
+            text = "hello",
+            files = listOf(
+                AppFile.Remote(FileProperty.Id(0, "id1")),
+                AppFile.Remote(FileProperty.Id(0, "id2")),
+                AppFile.Local("test", "/test/test1", "image/jpeg", null, false, null, 0),
+                AppFile.Local("test", "/test/test2", "image/jpeg", null, false, null, 0),
+                AppFile.Local("test", "/test/test3", "image/jpeg", null, false, null, 0)
+            )
+        )
+        val updatedState = state.toggleFileSensitiveStatus(targetFile)
+        val expectedFile = targetFile.copy(isSensitive = true)
+        assertEquals(expectedFile, updatedState.files[3])
+        assertNotSame(expectedFile, updatedState.files[0])
+        assertNotSame(expectedFile, updatedState.files[1])
+        assertNotSame(expectedFile, updatedState.files[2])
+        assertNotSame(expectedFile, updatedState.files[4])
+    }
 }


### PR DESCRIPTION
## やったこと
チャンネルを指定してノートを作成しようとした場合、
送信先がそのチャンネルになるようにしました。


## 動作確認
CIが通ること
実機テスト時にチャンネルを指定して投稿した時、
保存している公開範囲が変更されないこと。
チャンネルタイムラインを表示している時に、編集画面を表示した時
内部的にチャンネルIdを持っていて対象のチャンネルに対して投稿がされること。

## 関連リンク
Closed #487 