### PR TITLE
Display alt text when long-pressing image

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/media/MediaPreviewHelper.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/media/MediaPreviewHelper.kt
@@ -14,6 +14,7 @@ import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import jp.panta.misskeyandroidclient.R
 import jp.panta.misskeyandroidclient.ui.notes.view.media.PreviewAbleFileListAdapter
 import jp.panta.misskeyandroidclient.ui.notes.viewmodel.media.MediaViewData
@@ -103,6 +104,21 @@ object MediaPreviewHelper {
         }
         thumbnailView.setOnClickListener(listener)
         playButton.setOnClickListener(listener)
+
+        val holdListener = View.OnLongClickListener {
+            val context = it.context
+            val title = previewAbleFile?.file?.name
+            val altText = previewAbleFile?.file?.comment
+            val alertDialog = MaterialAlertDialogBuilder(context)
+            alertDialog.setTitle(title)
+            alertDialog.setMessage(altText)
+            alertDialog.setNeutralButton("Exit") { intf, _ ->
+                intf.cancel()
+            }
+            alertDialog.show()
+            true
+        }
+        thumbnailView.setOnLongClickListener(holdListener)
     }
 
 

--- a/model/src/main/java/net/pantasystem/milktea/model/drive/FileProperty.kt
+++ b/model/src/main/java/net/pantasystem/milktea/model/drive/FileProperty.kt
@@ -41,7 +41,9 @@ data class FileProperty (
             id,
             null,
             thumbnailUrl,
-            isSensitive
+            isSensitive,
+            null,
+            comment
         )
     }
 

--- a/model/src/main/java/net/pantasystem/milktea/model/file/File.kt
+++ b/model/src/main/java/net/pantasystem/milktea/model/file/File.kt
@@ -36,7 +36,8 @@ data class File(
     val localFileId: Long?,
     val thumbnailUrl: String?,
     val isSensitive: Boolean?,
-    val folderId: String? = null
+    val folderId: String? = null,
+    val comment: String? = null,
 ) : JSerializable {
     enum class AboutMediaType {
         VIDEO, IMAGE, SOUND, OTHER


### PR DESCRIPTION
## やったこと
When holding an image, the alt text / caption will be shown in a dialog box.

## 動作確認
Tested in emulator

## スクリーンショット(任意)
Demo can be seen here: https://mk.himbeer.me/notes/91fec8c7s7

## 備考
This is the first time I ever did anything related to Android development and also I don't speak Japanese, sorry if I did something wrong.

## 関連リンク
* ＜該当するJIRAチケットやIssueがあればそのURLを貼る＞

## TODO
* [ ] `CHANGES.md` に新しいバージョンと変更点を記載
    - バージョニングは[セマンティックバージョニング](https://semver.org/lang/ja/)に従い、 `X.Y.Z` の形式で付ける
