### PR TITLE
メモリリーク対策＆パフォーマンス改善

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/PlaneNoteViewDataCache.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/PlaneNoteViewDataCache.kt
@@ -45,6 +45,19 @@ class PlaneNoteViewDataCache(
         }
     }
 
+    suspend fun clear() {
+        return lock.withLock {
+            releaseAll(cache.values.toList())
+            cache.clear()
+        }
+    }
+
+    private fun releaseAll(list: List<PlaneNoteViewData>) {
+        list.map { note ->
+            note.job?.cancel()
+        }
+    }
+
     private suspend fun getUnThreadSafe(relation: NoteRelation): PlaneNoteViewData {
         val note = cache[relation.note.id]
 

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/TimelineViewModel.kt
@@ -111,6 +111,7 @@ class TimelineViewModel @AssistedInject constructor(
 
     fun loadInit() {
         viewModelScope.launch(Dispatchers.IO) {
+            cache.clear()
             timelineStore.clear()
             timelineStore.loadPrevious()
         }

--- a/data/src/main/java/net/pantasystem/milktea/data/gettters/NoteRelationGetter.kt
+++ b/data/src/main/java/net/pantasystem/milktea/data/gettters/NoteRelationGetter.kt
@@ -5,6 +5,7 @@ import net.pantasystem.milktea.model.drive.FilePropertyDataSource
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notes.NoteRelation
 import net.pantasystem.milktea.model.notes.NoteRepository
+import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserDataSource
 
 
@@ -15,38 +16,84 @@ class NoteRelationGetter(
     private val logger: Logger
 ) {
 
-    suspend fun get(noteId: Note.Id, deep: Boolean = true, featuredId: String? = null, promotionId: String? = null): NoteRelation? {
+    suspend fun get(
+        noteId: Note.Id,
+        deep: Boolean = true,
+        featuredId: String? = null,
+        promotionId: String? = null,
+        usersMap: Map<User.Id, User> = emptyMap(),
+        notesMap: Map<Note.Id, Note> = emptyMap(),
+    ): NoteRelation? {
         return runCatching {
-            noteRepository.find(noteId)
+            notesMap.getOrElse(noteId) {
+                noteRepository.find(noteId)
+            }
         }.onFailure {
             logger.error("ノートの取得に失敗しました", e = it)
-        }.getOrNull()?.let{
-            get(it, deep, featuredId = featuredId, promotionId = promotionId)
+        }.getOrNull()?.let {
+            get(
+                it,
+                deep,
+                featuredId = featuredId,
+                promotionId = promotionId,
+                usersMap = usersMap,
+                notesMap = notesMap
+            )
         }
     }
 
-    suspend fun get(accountId: Long, noteId: String, featuredId: String? = null, promotionId: String? = null): NoteRelation? {
+    suspend fun getIn(noteIds: List<Note.Id>): List<NoteRelation> {
+        val notes = noteRepository.findIn(noteIds)
+        val users = userDataSource.getIn(notes.map { it.userId }).associateBy {
+            it.id
+        }
+        val noteMap = notes.associateBy { it.id }
+        return notes.map {
+            get(
+                it,
+                true,
+                featuredId = null,
+                promotionId = null,
+                usersMap = users,
+                notesMap = noteMap
+            )
+        }
+    }
+
+    suspend fun get(
+        accountId: Long,
+        noteId: String,
+        featuredId: String? = null,
+        promotionId: String? = null
+    ): NoteRelation? {
         return get(Note.Id(accountId, noteId), featuredId = featuredId, promotionId = promotionId)
     }
 
 
+    suspend fun get(
+        note: Note,
+        deep: Boolean = true,
+        featuredId: String? = null,
+        promotionId: String? = null,
+        usersMap: Map<User.Id, User> = emptyMap(),
+        notesMap: Map<Note.Id, Note> = emptyMap(),
+    ): NoteRelation {
+        val user = usersMap.getOrElse(note.userId) {
+            userDataSource.get(note.userId)
+        }
 
-
-    suspend fun get(note: Note, deep: Boolean = true, featuredId: String? = null, promotionId: String? = null): NoteRelation {
-        val user = userDataSource.get(note.userId)
-
-        val renote = if(deep) {
-            note.renoteId?.let{
+        val renote = if (deep) {
+            note.renoteId?.let {
                 get(it, false)
             }
         } else null
-        val reply = if(deep) {
-            note.replyId?.let{
-                get(it, false)
+        val reply = if (deep) {
+            note.replyId?.let {
+                get(it, false, notesMap = notesMap, usersMap = usersMap)
             }
-        }else null
+        } else null
 
-        if(featuredId != null) {
+        if (featuredId != null) {
             return NoteRelation.Featured(
                 note,
                 user,
@@ -57,7 +104,7 @@ class NoteRelationGetter(
             )
         }
 
-        if(promotionId != null) {
+        if (promotionId != null) {
             return NoteRelation.Promotion(
                 note,
                 user,

--- a/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/TimelineStoreImpl.kt
+++ b/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/TimelineStoreImpl.kt
@@ -139,9 +139,7 @@ class TimelineStoreImpl(
         noteDataSource.state.flatMapLatest {
             timelineState.map { pageableState ->
                 pageableState.suspendConvert { list ->
-                    list.distinct().mapNotNull {
-                        getters.noteRelationGetter.get(it)
-                    }
+                    getters.noteRelationGetter.getIn(list.distinct())
                 }
             }
         }

--- a/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/InMemoryNoteDataSource.kt
+++ b/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/InMemoryNoteDataSource.kt
@@ -57,6 +57,14 @@ class InMemoryNoteDataSource @Inject constructor(
         }
     }
 
+    override suspend fun getIn(noteIds: List<Note.Id>): List<Note> {
+        mutex.withLock {
+            return noteIds.mapNotNull { noteId ->
+                notes[noteId]
+            }
+        }
+    }
+
     /**
      * @param note 追加するノート
      * @return ノートが新たに追加されるとtrue、上書きされた場合はfalseが返されます。

--- a/model/src/main/java/net/pantasystem/milktea/model/notes/NoteDataSource.kt
+++ b/model/src/main/java/net/pantasystem/milktea/model/notes/NoteDataSource.kt
@@ -47,6 +47,8 @@ interface NoteDataSource {
 
     val state: StateFlow<NoteDataSourceState>
 
+    suspend fun getIn(noteIds: List<Note.Id>) : List<Note>
+
     @Throws(NoteNotFoundException::class)
     suspend fun get(noteId: Note.Id) : Note
 

--- a/model/src/main/java/net/pantasystem/milktea/model/notes/NoteRepository.kt
+++ b/model/src/main/java/net/pantasystem/milktea/model/notes/NoteRepository.kt
@@ -10,6 +10,8 @@ interface NoteRepository {
 
     suspend fun find(noteId: Note.Id): Note
 
+    suspend fun findIn(noteIds: List<Note.Id>): List<Note>
+
     suspend fun reaction(createReaction: CreateReaction): Boolean
 
     suspend fun unreaction(noteId: Note.Id): Boolean

--- a/model/src/main/java/net/pantasystem/milktea/model/user/UserDataSource.kt
+++ b/model/src/main/java/net/pantasystem/milktea/model/user/UserDataSource.kt
@@ -49,6 +49,8 @@ interface UserDataSource {
 
     suspend fun get(userId: User.Id): User
 
+    suspend fun getIn(userIds: List<User.Id>): List<User>
+
     suspend fun get(accountId: Long, userName: String, host: String?): User
 
     suspend fun add(user: User): AddResult


### PR DESCRIPTION
## やったこと
O(1)でしかもHashMapへのアクセスなので計算量はほぼ皆無かと思っていたが、
実はMutexでロックしているため以外にも計算量が多い＆ブロッキングが多い可能性が出てきた
そこでIdをまとめて指定して取得するなどの工夫をすることにより、なるべく少ないロック回数で取得できるようにしました。
またメモリリークしかねない実装があったので解放するようにしました。