### PR TITLE
ユーザー詳細画面のスクロールの不具合を修正しました

### DIFF
--- a/app/src/main/res/layout/activity_user_detail.xml
+++ b/app/src/main/res/layout/activity_user_detail.xml
@@ -22,7 +22,7 @@
             <com.google.android.material.appbar.CollapsingToolbarLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:layout_scrollFlags="scroll|exitUntilCollapsed"
+                    app:layout_scrollFlags="scroll|exitUntilCollapsed|snap"
                     >
 
                 <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
## やったこと
### before 
スクロール部分が先行してしまう、スクロールできない不具合がありました。
### After
snapフラグを追加することによってスムーズにスクロールをできるようにしました。
